### PR TITLE
Change systemd type to "simple"

### DIFF
--- a/system/systemd/kazoo-rabbitmq.service
+++ b/system/systemd/kazoo-rabbitmq.service
@@ -3,7 +3,7 @@ Description=RabbitMQ Broker Configured for Kazoo
 After=syslog.target network-online.target
 
 [Service]
-Type=notify
+Type=simple
 User=rabbitmq
 Group=daemon
 PermissionsStartOnly=true


### PR DESCRIPTION
Introduction
============

On CentOS, the `erlang-sd_notify` package (it's in `epel`) is used to
provide communication between RabbitMQ and systemd. "notify" is
consequently the right type to use - for CentOS.

When starting `kazoo-rabbitmq` on Debian, the "notify" type
makes systemd block, waiting for an API notification that never comes,
so it times out and kills RabbitMQ.

The quickest and easiest way to overcome this is to change the systemd
service type to "simple", which will work on both Debian and CentOS.

Why not just use `erlang-sd_notify` in Debian?
----------------------------------------------

It's not yet part of the official Debian distribution, although
an [RFP][] was put in during early 2016 and has received little
attention since then.

A Debian `.deb` package is available in a Github [repo][], but it has
unfortunate dependencies and caused no end of trouble for me during
installation.

Limitations
-----------

A potential downside of using "simple" is that if RabbitMQ ever takes a
long time to start up, the timeout may happen anyway, which is why
`erlang-sd_notify` was created in the first place - to give status
messages to systemd during startup that avoid it killing RabbitMQ
prematurely.

Why not create our own build?
-----------------------------

Good idea!

There is an "official" systemd git [repo][] for `erlang-sd_notify`, so I
created a `baggage-claim` Debian build for it (surprisingly named
`erlang-sd-notify`).

I did not use the upstream Debian packaging because it doesn't fit our
`baggage-claim` use case very well, and, well, I don't really appreciate
the way it's done.

Most annoyingly, the latest Github release is tagged as `v1.0`, which
required some contortions within `baggage-claim` to keep the version
with the 'v' long enough to download the release tarball, but find a way
to strip it off after that to avoid Debian build problems.

It also means that running `build.sh` requires a version of `v1 0` to
work correctly (gitswitch take note).

The `erlang-sd-notify` build completes successfully, and the package
installs successfully, but I have not yet tested the package
functionality.

At least we have a mostly-complete Plan B if "simple" turns out to be,
well, not so simple.

[RFP]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=813634
[repo]: https://github.com/systemd/erlang-sd_notify